### PR TITLE
Chore: refacto navigation by using savedStateHandle

### DIFF
--- a/app/src/main/java/com/illiouchine/jm/MainActivity.kt
+++ b/app/src/main/java/com/illiouchine/jm/MainActivity.kt
@@ -24,7 +24,7 @@ import com.illiouchine.jm.logic.SettingsViewModel
 import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.ui.Destination
 import com.illiouchine.jm.ui.NavigationAction
-import com.illiouchine.jm.ui.Navigator2
+import com.illiouchine.jm.ui.Navigator
 import com.illiouchine.jm.ui.ObserveAsEvents
 import com.illiouchine.jm.ui.Screens
 import com.illiouchine.jm.ui.screen.AboutScreen
@@ -46,9 +46,9 @@ class MainActivity : ComponentActivity() {
         setContent {
 
             val navController = rememberNavController()
-            val navigator2 : Navigator2 by inject<Navigator2>()
+            val navigator : Navigator by inject<Navigator>()
 
-            ObserveAsEvents(navigator2.navigationAction) { action ->
+            ObserveAsEvents(navigator.navigationAction) { action ->
                 when(action) {
                     is NavigationAction.Navigate -> navController.navigate(
                         action.destination
@@ -67,7 +67,7 @@ class MainActivity : ComponentActivity() {
             JmTheme {
                 NavHost(
                     navController = navController,
-                    startDestination = navigator2.startDestination,
+                    startDestination = navigator.startDestination,
                 ) {
                     composable<Destination.Home> {
                         val homeViewModel: HomeViewModel by viewModel()

--- a/app/src/main/java/com/illiouchine/jm/MajorityUrnApplication.kt
+++ b/app/src/main/java/com/illiouchine/jm/MajorityUrnApplication.kt
@@ -1,7 +1,6 @@
 package com.illiouchine.jm
 
 import android.app.Application
-import androidx.navigation.Navigator
 import androidx.room.Room
 import com.illiouchine.jm.data.SqlitePollDataSource
 import com.illiouchine.jm.data.PollDataSource
@@ -15,7 +14,6 @@ import com.illiouchine.jm.logic.PollVotingViewModel
 import com.illiouchine.jm.logic.SettingsViewModel
 import com.illiouchine.jm.ui.DefaultNavigator
 import com.illiouchine.jm.ui.Destination
-import com.illiouchine.jm.ui.Navigator2
 import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
@@ -56,7 +54,7 @@ val module = module {
 
 
     // compose
-    single<Navigator2> {
+    single<com.illiouchine.jm.ui.Navigator> {
         DefaultNavigator(startDestination = Destination.Home)
     }
 

--- a/app/src/main/java/com/illiouchine/jm/MajorityUrnApplication.kt
+++ b/app/src/main/java/com/illiouchine/jm/MajorityUrnApplication.kt
@@ -54,10 +54,15 @@ val module = module {
     single { Navigator() }
 
     // ViewModel
-    viewModel { HomeViewModel(pollDataSource = get(), navigator = get()) }
+    viewModel { HomeViewModel(
+        pollDataSource = get(),
+        navigator = get(),
+        prefsHelper = get()
+    ) }
     viewModel { SettingsViewModel(sharedPreferences = get()) }
     viewModel {
         PollSetupViewModel(
+            savedStateHandle = get(),
             sharedPrefsHelper = get(),
             pollDataSource = get(),
             navigator = get(),
@@ -65,6 +70,7 @@ val module = module {
     }
     viewModel {
         PollVotingViewModel(
+            savedStateHandle = get(),
             pollDataSource = get(),
             sharedPrefsHelper = get(),
             navigator = get(),
@@ -72,6 +78,7 @@ val module = module {
     }
     viewModel {
         PollResultViewModel(
+            savedStateHandle = get(),
             navigator = get(),
         )
     }

--- a/app/src/main/java/com/illiouchine/jm/MajorityUrnApplication.kt
+++ b/app/src/main/java/com/illiouchine/jm/MajorityUrnApplication.kt
@@ -1,6 +1,7 @@
 package com.illiouchine.jm
 
 import android.app.Application
+import androidx.navigation.Navigator
 import androidx.room.Room
 import com.illiouchine.jm.data.SqlitePollDataSource
 import com.illiouchine.jm.data.PollDataSource
@@ -12,9 +13,12 @@ import com.illiouchine.jm.logic.PollResultViewModel
 import com.illiouchine.jm.logic.PollSetupViewModel
 import com.illiouchine.jm.logic.PollVotingViewModel
 import com.illiouchine.jm.logic.SettingsViewModel
-import com.illiouchine.jm.ui.Navigator
+import com.illiouchine.jm.ui.DefaultNavigator
+import com.illiouchine.jm.ui.Destination
+import com.illiouchine.jm.ui.Navigator2
 import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
@@ -25,6 +29,7 @@ class MajorityUrnApplication : Application() {
         super.onCreate()
         startKoin {
             androidContext(this@MajorityUrnApplication)
+            androidLogger()
             modules(module)
         }
     }
@@ -51,7 +56,9 @@ val module = module {
 
 
     // compose
-    single { Navigator() }
+    single<Navigator2> {
+        DefaultNavigator(startDestination = Destination.Home)
+    }
 
     // ViewModel
     viewModel { HomeViewModel(

--- a/app/src/main/java/com/illiouchine/jm/logic/HomeViewModel.kt
+++ b/app/src/main/java/com/illiouchine/jm/logic/HomeViewModel.kt
@@ -3,6 +3,7 @@ package com.illiouchine.jm.logic
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.illiouchine.jm.data.PollDataSource
+import com.illiouchine.jm.data.SharedPrefsHelper
 import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.ui.Navigator
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,10 +14,12 @@ import kotlinx.coroutines.launch
 class HomeViewModel(
     private val pollDataSource: PollDataSource,
     private val navigator: Navigator,
+    private val prefsHelper: SharedPrefsHelper,
 ) : ViewModel() {
 
     data class HomeViewState(
-        val polls: List<Poll> = emptyList()
+        val polls: List<Poll> = emptyList(),
+        val showOnboarding: Boolean = false,
     )
 
     private val _homeViewState = MutableStateFlow<HomeViewState>(HomeViewState())
@@ -24,6 +27,25 @@ class HomeViewModel(
 
     init {
         loadPolls()
+        loadSharedPref()
+    }
+
+    private fun loadSharedPref() {
+        viewModelScope.launch {
+            val showOnboarding = prefsHelper.getShowOnboarding()
+            _homeViewState.update {
+                it.copy(showOnboarding = showOnboarding)
+            }
+        }
+    }
+
+    fun onOnboardingFinished() {
+        viewModelScope.launch {
+            prefsHelper.editShowOnboarding(false)
+            _homeViewState.update {
+                it.copy(showOnboarding = false)
+            }
+        }
     }
 
     fun loadPolls() {

--- a/app/src/main/java/com/illiouchine/jm/logic/HomeViewModel.kt
+++ b/app/src/main/java/com/illiouchine/jm/logic/HomeViewModel.kt
@@ -5,7 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.illiouchine.jm.data.PollDataSource
 import com.illiouchine.jm.data.SharedPrefsHelper
 import com.illiouchine.jm.model.Poll
-import com.illiouchine.jm.ui.Navigator
+import com.illiouchine.jm.ui.Destination
+import com.illiouchine.jm.ui.Navigator2
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -13,7 +14,7 @@ import kotlinx.coroutines.launch
 
 class HomeViewModel(
     private val pollDataSource: PollDataSource,
-    private val navigator: Navigator,
+    private val navigator: Navigator2,
     private val prefsHelper: SharedPrefsHelper,
 ) : ViewModel() {
 
@@ -68,6 +69,30 @@ class HomeViewModel(
         viewModelScope.launch {
             pollDataSource.deletePoll(poll)
             loadPolls()
+        }
+    }
+
+    fun setupBlankPoll() {
+        viewModelScope.launch {
+            navigator.navigate(Destination.PollSetup())
+        }
+    }
+
+    fun setupPoll(poll : Poll) {
+        viewModelScope.launch {
+            navigator.navigate(Destination.PollSetup(poll.id))
+        }
+    }
+
+    fun resumePoll(poll: Poll){
+        viewModelScope.launch {
+            navigator.navigate(Destination.PollVote(poll.id))
+        }
+    }
+
+    fun showResult(poll: Poll) {
+        viewModelScope.launch {
+            navigator.navigate(Destination.PollResult(poll.id))
         }
     }
 }

--- a/app/src/main/java/com/illiouchine/jm/logic/HomeViewModel.kt
+++ b/app/src/main/java/com/illiouchine/jm/logic/HomeViewModel.kt
@@ -6,7 +6,7 @@ import com.illiouchine.jm.data.PollDataSource
 import com.illiouchine.jm.data.SharedPrefsHelper
 import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.ui.Destination
-import com.illiouchine.jm.ui.Navigator2
+import com.illiouchine.jm.ui.Navigator
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -14,7 +14,7 @@ import kotlinx.coroutines.launch
 
 class HomeViewModel(
     private val pollDataSource: PollDataSource,
-    private val navigator: Navigator2,
+    private val navigator: Navigator,
     private val prefsHelper: SharedPrefsHelper,
 ) : ViewModel() {
 

--- a/app/src/main/java/com/illiouchine/jm/logic/PollResultViewModel.kt
+++ b/app/src/main/java/com/illiouchine/jm/logic/PollResultViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.ui.Destination
-import com.illiouchine.jm.ui.Navigator2
+import com.illiouchine.jm.ui.Navigator
 import com.illiouchine.jm.ui.Screens
 import com.illiouchine.jm.ui.mapType
 import fr.mieuxvoter.mj.CollectedTally
@@ -20,7 +20,7 @@ import kotlinx.coroutines.launch
 
 class PollResultViewModel(
     savedStateHandle: SavedStateHandle,
-    private val navigator: Navigator2,
+    private val navigator: Navigator,
 ) : ViewModel() {
 
     private val pollResult = savedStateHandle.toRoute<Screens.PollResult>(Screens.PollResult.mapType())

--- a/app/src/main/java/com/illiouchine/jm/logic/PollResultViewModel.kt
+++ b/app/src/main/java/com/illiouchine/jm/logic/PollResultViewModel.kt
@@ -2,9 +2,11 @@ package com.illiouchine.jm.logic
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.illiouchine.jm.model.Poll
-import com.illiouchine.jm.ui.Navigator
+import com.illiouchine.jm.ui.Destination
+import com.illiouchine.jm.ui.Navigator2
 import com.illiouchine.jm.ui.Screens
 import com.illiouchine.jm.ui.mapType
 import fr.mieuxvoter.mj.CollectedTally
@@ -14,10 +16,11 @@ import fr.mieuxvoter.mj.ResultInterface
 import fr.mieuxvoter.mj.TallyInterface
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
 class PollResultViewModel(
     savedStateHandle: SavedStateHandle,
-    private val navigator: Navigator,
+    private val navigator: Navigator2,
 ) : ViewModel() {
 
     private val pollResult = savedStateHandle.toRoute<Screens.PollResult>(Screens.PollResult.mapType())
@@ -51,5 +54,11 @@ class PollResultViewModel(
             tally = tally,
             result = result
         )
+    }
+
+    fun returnHome(){
+        viewModelScope.launch {
+            navigator.navigate(Destination.Home)
+        }
     }
 }

--- a/app/src/main/java/com/illiouchine/jm/logic/PollResultViewModel.kt
+++ b/app/src/main/java/com/illiouchine/jm/logic/PollResultViewModel.kt
@@ -1,8 +1,12 @@
 package com.illiouchine.jm.logic
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.navigation.toRoute
 import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.ui.Navigator
+import com.illiouchine.jm.ui.Screens
+import com.illiouchine.jm.ui.mapType
 import fr.mieuxvoter.mj.CollectedTally
 import fr.mieuxvoter.mj.DeliberatorInterface
 import fr.mieuxvoter.mj.MajorityJudgmentDeliberator
@@ -10,11 +14,13 @@ import fr.mieuxvoter.mj.ResultInterface
 import fr.mieuxvoter.mj.TallyInterface
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.update
 
 class PollResultViewModel(
+    savedStateHandle: SavedStateHandle,
     private val navigator: Navigator,
 ) : ViewModel() {
+
+    private val pollResult = savedStateHandle.toRoute<Screens.PollResult>(Screens.PollResult.mapType())
 
     data class PollResultViewState(
         val poll: Poll? = null,
@@ -22,10 +28,10 @@ class PollResultViewModel(
         val result: ResultInterface? = null,
     )
 
-    private val _pollResultViewState = MutableStateFlow<PollResultViewState>(PollResultViewState())
+    private val _pollResultViewState = MutableStateFlow<PollResultViewState>(initializeState(pollResult.poll))
     val pollResultViewState: StateFlow<PollResultViewState> = _pollResultViewState
 
-    fun initializePollResult(poll: Poll) {
+    private fun initializeState(poll: Poll) : PollResultViewState {
         val amountOfProposals = poll.pollConfig.proposals.size
         val amountOfGrades = poll.pollConfig.grading.getAmountOfGrades()
         val deliberation: DeliberatorInterface = MajorityJudgmentDeliberator()
@@ -40,12 +46,10 @@ class PollResultViewModel(
 
         val result: ResultInterface = deliberation.deliberate(tally)
 
-        _pollResultViewState.update {
-            it.copy(
-                poll = poll,
-                tally = tally,
-                result = result,
-            )
-        }
+        return PollResultViewState(
+            poll = poll,
+            tally = tally,
+            result = result
+        )
     }
 }

--- a/app/src/main/java/com/illiouchine/jm/logic/PollSetupViewModel.kt
+++ b/app/src/main/java/com/illiouchine/jm/logic/PollSetupViewModel.kt
@@ -2,8 +2,10 @@ package com.illiouchine.jm.logic
 
 import android.content.Context
 import androidx.annotation.StringRes
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.illiouchine.jm.R
 import com.illiouchine.jm.data.PollDataSource
 import com.illiouchine.jm.data.SharedPrefsHelper
@@ -12,6 +14,7 @@ import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.model.PollConfig
 import com.illiouchine.jm.ui.Navigator
 import com.illiouchine.jm.ui.Screens
+import com.illiouchine.jm.ui.mapType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -20,10 +23,13 @@ import java.text.DateFormat
 import java.util.Calendar
 
 class PollSetupViewModel(
+    savedStateHandle: SavedStateHandle,
     private val sharedPrefsHelper: SharedPrefsHelper,
     private val pollDataSource: PollDataSource,
     private val navigator: Navigator,
 ) : ViewModel() {
+
+    private val pollSetup = savedStateHandle.toRoute<Screens.PollSetup>(Screens.PollSetup.mapType())
 
     data class PollSetupViewState(
         val config: PollConfig = PollConfig(),
@@ -32,15 +38,8 @@ class PollSetupViewModel(
         @StringRes val feedback: Int? = null,
     )
 
-    private val _pollSetupViewState = MutableStateFlow(PollSetupViewState())
+    private val _pollSetupViewState = MutableStateFlow(PollSetupViewState(config = initWithConfig(pollSetup.config)))
     val pollSetupViewState: StateFlow<PollSetupViewState> = _pollSetupViewState
-
-    fun initWithConfig(config: PollConfig? = null) {
-        val initialPollConfig = config ?: PollConfig(grading = sharedPrefsHelper.getDefaultGrading())
-        _pollSetupViewState.update {
-            it.copy(config = initialPollConfig)
-        }
-    }
 
     fun addSubject(context: Context, subject: String) {
         val newSubject = subject.ifEmpty { generateSubject(context = context) }
@@ -147,6 +146,8 @@ class PollSetupViewModel(
             navigator.navigateTo(Screens.PollVote(pollId = pollId))
         }
     }
+
+    private fun initWithConfig(config: PollConfig? = null) = config ?: PollConfig(grading = sharedPrefsHelper.getDefaultGrading())
 
     private fun generateProposalName(context: Context): String {
         return buildString {

--- a/app/src/main/java/com/illiouchine/jm/logic/PollSetupViewModel.kt
+++ b/app/src/main/java/com/illiouchine/jm/logic/PollSetupViewModel.kt
@@ -13,7 +13,7 @@ import com.illiouchine.jm.model.Grading
 import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.model.PollConfig
 import com.illiouchine.jm.ui.Destination
-import com.illiouchine.jm.ui.Navigator2
+import com.illiouchine.jm.ui.Navigator
 import com.illiouchine.jm.ui.Screens
 import com.illiouchine.jm.ui.mapType
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,7 +27,7 @@ class PollSetupViewModel(
     savedStateHandle: SavedStateHandle,
     private val sharedPrefsHelper: SharedPrefsHelper,
     private val pollDataSource: PollDataSource,
-    private val navigator: Navigator2,
+    private val navigator: Navigator,
 ) : ViewModel() {
 
     private val pollSetup = savedStateHandle.toRoute<Screens.PollSetup>(Screens.PollSetup.mapType())

--- a/app/src/main/java/com/illiouchine/jm/logic/PollSetupViewModel.kt
+++ b/app/src/main/java/com/illiouchine/jm/logic/PollSetupViewModel.kt
@@ -12,7 +12,8 @@ import com.illiouchine.jm.data.SharedPrefsHelper
 import com.illiouchine.jm.model.Grading
 import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.model.PollConfig
-import com.illiouchine.jm.ui.Navigator
+import com.illiouchine.jm.ui.Destination
+import com.illiouchine.jm.ui.Navigator2
 import com.illiouchine.jm.ui.Screens
 import com.illiouchine.jm.ui.mapType
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,7 +27,7 @@ class PollSetupViewModel(
     savedStateHandle: SavedStateHandle,
     private val sharedPrefsHelper: SharedPrefsHelper,
     private val pollDataSource: PollDataSource,
-    private val navigator: Navigator,
+    private val navigator: Navigator2,
 ) : ViewModel() {
 
     private val pollSetup = savedStateHandle.toRoute<Screens.PollSetup>(Screens.PollSetup.mapType())
@@ -143,7 +144,7 @@ class PollSetupViewModel(
                 ballots = emptyList(),
             )
             val pollId = pollDataSource.savePoll(poll)
-            navigator.navigateTo(Screens.PollVote(pollId = pollId))
+            navigator.navigate(Destination.PollVote(pollId))
         }
     }
 

--- a/app/src/main/java/com/illiouchine/jm/ui/Navigator.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/Navigator.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
 
 class Navigator {
 
@@ -30,6 +32,26 @@ sealed class Screens {
     @Serializable data class PollVote(val pollId: Int) :Screens()
     @Serializable data class PollResult(val poll: Poll) : Screens()
 }
+
+fun Screens.PollSetup.Companion.mapType() : Map<KType, @JvmSuppressWildcards NavType<*>> {
+    return mapOf(
+        typeOf<PollConfig?>() to CustomNavType.NullablePollConfigType,
+    )
+}
+
+fun Screens.PollVote.Companion.mapType() : Map<KType, @JvmSuppressWildcards NavType<*>> {
+    return mapOf(
+        typeOf<PollConfig>() to CustomNavType.PollConfigType,
+        typeOf<List<Ballot>>() to CustomNavType.Ballots,
+    )
+}
+
+fun Screens.PollResult.Companion.mapType() : Map<KType, @JvmSuppressWildcards NavType<*>> {
+    return mapOf(
+        typeOf<Poll>() to CustomNavType.Poll,
+    )
+}
+
 
 object CustomNavType {
 

--- a/app/src/main/java/com/illiouchine/jm/ui/Navigator.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/Navigator.kt
@@ -40,7 +40,7 @@ sealed interface NavigationAction {
     data object NavigateUp : NavigationAction
 }
 
-interface Navigator2 {
+interface Navigator {
     val startDestination: Destination
     val navigationAction: Flow<NavigationAction>
 
@@ -54,7 +54,7 @@ interface Navigator2 {
 
 class DefaultNavigator(
     override val startDestination: Destination,
-) : Navigator2 {
+) : Navigator {
     private val _navigationAction = Channel<NavigationAction>()
     override val navigationAction: Flow<NavigationAction> = _navigationAction.receiveAsFlow()
 
@@ -75,28 +75,36 @@ class DefaultNavigator(
     }
 }
 
+@Deprecated("")
 @Serializable
 sealed class Screens {
     @Serializable
     data object Home : Screens()
+
     @Serializable
     data object Settings : Screens()
+
     @Serializable
     data object About : Screens()
+
     @Serializable
     data class PollSetup(val config: PollConfig? = null) : Screens()
+
     @Serializable
     data class PollVote(val pollId: Int) : Screens()
+
     @Serializable
     data class PollResult(val poll: Poll) : Screens()
 }
 
+@Deprecated("")
 fun Screens.PollSetup.Companion.mapType(): Map<KType, @JvmSuppressWildcards NavType<*>> {
     return mapOf(
         typeOf<PollConfig?>() to CustomNavType.NullablePollConfigType,
     )
 }
 
+@Deprecated("")
 fun Screens.PollVote.Companion.mapType(): Map<KType, @JvmSuppressWildcards NavType<*>> {
     return mapOf(
         typeOf<PollConfig>() to CustomNavType.PollConfigType,
@@ -104,13 +112,14 @@ fun Screens.PollVote.Companion.mapType(): Map<KType, @JvmSuppressWildcards NavTy
     )
 }
 
+@Deprecated("")
 fun Screens.PollResult.Companion.mapType(): Map<KType, @JvmSuppressWildcards NavType<*>> {
     return mapOf(
         typeOf<Poll>() to CustomNavType.Poll,
     )
 }
 
-
+@Deprecated("")
 object CustomNavType {
 
     val NullablePollConfigType = object : NavType<PollConfig?>(isNullableAllowed = true) {

--- a/app/src/main/java/com/illiouchine/jm/ui/ObserveAsEvents.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/ObserveAsEvents.kt
@@ -1,0 +1,30 @@
+package com.illiouchine.jm.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+
+@Composable
+fun <T> ObserveAsEvents(
+    flow: Flow<T>,
+    key1: Any? = null,
+    key2: Any? = null,
+    onEvent: (T) -> Unit
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(
+        key1 = lifecycleOwner.lifecycle,
+        key1, key2
+    ) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            withContext(Dispatchers.Main.immediate) {
+                flow.collect(onEvent)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/illiouchine/jm/ui/screen/PollResultScreen.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/screen/PollResultScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,12 +32,18 @@ import com.illiouchine.jm.model.Grading
 import com.illiouchine.jm.model.Judgment
 import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.model.PollConfig
-import com.illiouchine.jm.ui.Navigator
 import com.illiouchine.jm.ui.composable.BallotCountRow
 import com.illiouchine.jm.ui.composable.LinearMeritProfileCanvas
 import com.illiouchine.jm.ui.composable.MjuSnackbar
 import com.illiouchine.jm.ui.composable.PollSubject
 import com.illiouchine.jm.ui.theme.JmTheme
+import fr.mieuxvoter.mj.ProposalResult
+import fr.mieuxvoter.mj.ProposalResultInterface
+import fr.mieuxvoter.mj.ProposalTally
+import fr.mieuxvoter.mj.ProposalTallyInterface
+import fr.mieuxvoter.mj.ResultInterface
+import fr.mieuxvoter.mj.TallyInterface
+import java.math.BigInteger
 import kotlin.math.max
 import kotlin.math.min
 
@@ -160,6 +165,21 @@ fun ResultScreen(
 @Preview(showSystemUi = true)
 @Composable
 fun PreviewResultScreen(modifier: Modifier = Modifier) {
+    /*
+    // FIXME : Clean this Preview by not exposing Majority Judgment Object
+    val pollResultViewModel = PollResultViewModel(
+        navigator = Navigator(),
+        savedStateHandle =
+    )
+    pollResultViewModel.initializePollResult(poll)
+    val state = pollResultViewModel.pollResultViewState.collectAsState().value
+    JmTheme {
+        ResultScreen(
+            state = state,
+        )
+    }
+    */
+
     val poll = Poll(
         pollConfig = PollConfig(
             subject = "Who for Prézidaaanh ?",
@@ -194,9 +214,39 @@ fun PreviewResultScreen(modifier: Modifier = Modifier) {
             ),
         ),
     )
-    val pollResultViewModel = PollResultViewModel(Navigator())
-    pollResultViewModel.initializePollResult(poll)
-    val state = pollResultViewModel.pollResultViewState.collectAsState().value
+
+    class DummyTally : TallyInterface {
+        override fun getProposalsTallies(): Array<ProposalTallyInterface> {
+            return listOf(ProposalTally()).toTypedArray()
+        }
+
+        override fun getAmountOfJudges(): BigInteger {
+            return BigInteger.valueOf(3L)
+        }
+
+        override fun getAmountOfProposals(): Int {
+            return 3
+        }
+    }
+
+    class JMResult: ResultInterface {
+        override fun getProposalResults(): Array<ProposalResultInterface> {
+            return listOf(ProposalResult()).toTypedArray()
+        }
+
+        override fun getProposalResultsRanked(): Array<ProposalResultInterface> {
+            return listOf(ProposalResult()).toTypedArray()
+        }
+    }
+
+    val dummyTally = DummyTally()
+    val jmResult = JMResult()
+    val state : PollResultViewModel.PollResultViewState = PollResultViewModel.PollResultViewState(
+        poll = poll,
+        tally = dummyTally,
+        result = jmResult
+    )
+
     JmTheme {
         ResultScreen(
             state = state,


### PR DESCRIPTION
Yolo Refacto : Use savedStateHandle to initiate VM state instead of custom function.
