### PR TITLE
Chore: Update navigator with type safe

### DIFF
--- a/app/src/main/java/com/illiouchine/jm/MajorityUrnApplication.kt
+++ b/app/src/main/java/com/illiouchine/jm/MajorityUrnApplication.kt
@@ -2,9 +2,9 @@ package com.illiouchine.jm
 
 import android.app.Application
 import androidx.room.Room
-import com.illiouchine.jm.data.SqlitePollDataSource
 import com.illiouchine.jm.data.PollDataSource
 import com.illiouchine.jm.data.SharedPrefsHelper
+import com.illiouchine.jm.data.SqlitePollDataSource
 import com.illiouchine.jm.data.room.PollDao
 import com.illiouchine.jm.data.room.PollDataBase
 import com.illiouchine.jm.logic.HomeViewModel
@@ -12,7 +12,9 @@ import com.illiouchine.jm.logic.PollResultViewModel
 import com.illiouchine.jm.logic.PollSetupViewModel
 import com.illiouchine.jm.logic.PollVotingViewModel
 import com.illiouchine.jm.logic.SettingsViewModel
+import com.illiouchine.jm.ui.DefaultNavigator
 import com.illiouchine.jm.ui.Navigator
+import com.illiouchine.jm.ui.Screens
 import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
@@ -50,11 +52,17 @@ val module = module {
     single<PollDataSource> { SqlitePollDataSource(get()) }
 
 
-    // compose
-    single { Navigator() }
+    // Navigation
+    single<Navigator> { DefaultNavigator(Screens.Home) }
 
     // ViewModel
-    viewModel { HomeViewModel(pollDataSource = get(), navigator = get()) }
+    viewModel {
+        HomeViewModel(
+            pollDataSource = get(),
+            navigator = get(),
+            sharedPrefsHelper = get()
+        )
+    }
     viewModel { SettingsViewModel(sharedPreferences = get()) }
     viewModel {
         PollSetupViewModel(
@@ -72,6 +80,7 @@ val module = module {
     }
     viewModel {
         PollResultViewModel(
+            pollDataSource = get(),
             navigator = get(),
         )
     }

--- a/app/src/main/java/com/illiouchine/jm/data/room/RoomMapper.kt
+++ b/app/src/main/java/com/illiouchine/jm/data/room/RoomMapper.kt
@@ -12,6 +12,7 @@ import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.model.PollConfig
 
 fun Poll.toPollEntity(): PollEntity = PollEntity(
+    uid = this.id,
     subject = this.pollConfig.subject,
     nbGrading = this.pollConfig.grading.grades.size,
 )

--- a/app/src/main/java/com/illiouchine/jm/logic/PollSetupViewModel.kt
+++ b/app/src/main/java/com/illiouchine/jm/logic/PollSetupViewModel.kt
@@ -35,10 +35,14 @@ class PollSetupViewModel(
     private val _pollSetupViewState = MutableStateFlow(PollSetupViewState())
     val pollSetupViewState: StateFlow<PollSetupViewState> = _pollSetupViewState
 
-    fun initWithConfig(config: PollConfig? = null) {
-        val initialPollConfig = config ?: PollConfig(grading = sharedPrefsHelper.getDefaultGrading())
-        _pollSetupViewState.update {
-            it.copy(config = initialPollConfig)
+    fun initialize(pollId: Int = 0) {
+        viewModelScope.launch {
+            val poll = pollDataSource.getPollById(pollId = pollId)
+            val initialPoll =
+                poll?.pollConfig ?: PollConfig(grading = sharedPrefsHelper.getDefaultGrading())
+            _pollSetupViewState.update {
+                it.copy(config = initialPoll)
+            }
         }
     }
 
@@ -144,7 +148,7 @@ class PollSetupViewModel(
                 ballots = emptyList(),
             )
             val pollId = pollDataSource.savePoll(poll)
-            navigator.navigateTo(Screens.PollVote(pollId = pollId))
+            navigator.navigateTo(Screens.PollVote(id = pollId))
         }
     }
 
@@ -171,6 +175,7 @@ class PollSetupViewModel(
         return newPoll
     }
 
-    private fun proposalAlreadyExist(proposal: String): Boolean = _pollSetupViewState.value.config.proposals.any { it == proposal }
+    private fun proposalAlreadyExist(proposal: String): Boolean =
+        _pollSetupViewState.value.config.proposals.any { it == proposal }
 
 }

--- a/app/src/main/java/com/illiouchine/jm/logic/PollVotingViewModel.kt
+++ b/app/src/main/java/com/illiouchine/jm/logic/PollVotingViewModel.kt
@@ -30,6 +30,7 @@ class PollVotingViewModel(
         val ballots: List<Ballot> = emptyList(),
         val currentBallot: Ballot? = null,
         val currentProposalsOrder: List<Int> = emptyList(),
+        val pinScreens: Boolean = true,
     ) {
         fun isInStateReady(): Boolean {
             return null == currentBallot
@@ -49,6 +50,7 @@ class PollVotingViewModel(
         pollId: Int,
     ) {
         viewModelScope.launch {
+            val pinScreens = sharedPrefsHelper.getPinScreen()
             val poll = pollDataSource.getPollById(pollId)
 
             _pollVotingViewState.update {
@@ -57,6 +59,7 @@ class PollVotingViewModel(
                     pollConfig = poll?.pollConfig ?: PollConfig(),
                     ballots = poll?.ballots ?: emptyList(),
                     currentBallot = null,
+                    pinScreens = pinScreens,
                 )
             }
         }
@@ -122,10 +125,12 @@ class PollVotingViewModel(
     fun finalizePoll() {
         viewModelScope.launch {
             val poll = Poll(
+                id = _pollVotingViewState.value.pollId,
                 pollConfig = _pollVotingViewState.value.pollConfig,
                 ballots = _pollVotingViewState.value.ballots,
             )
-            navigator.navigateTo(Screens.PollResult(poll = poll))
+            val newPollId = pollDataSource.savePoll(poll)
+            navigator.navigateTo(Screens.PollResult(id = newPollId))
         }
     }
 }

--- a/app/src/main/java/com/illiouchine/jm/ui/Navigator.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/Navigator.kt
@@ -2,34 +2,86 @@ package com.illiouchine.jm.ui
 
 import android.net.Uri
 import android.os.Bundle
+import androidx.navigation.NavOptionsBuilder
 import androidx.navigation.NavType
 import com.illiouchine.jm.model.Ballot
 import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.model.PollConfig
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
-class Navigator {
 
-    private val _sharedFlow = MutableSharedFlow<Screens>(extraBufferCapacity = 1)
-    val sharedFlow = _sharedFlow.asSharedFlow()
+sealed interface Screens {
+    @Serializable
+    data object Home : Screens
+    @Serializable
+    data object Settings : Screens
+    @Serializable
+    data object About : Screens
+    @Serializable
+    data class PollSetup(val id: Int = 0) : Screens
+    @Serializable
+    data class PollVote(val id: Int = 0) : Screens
+    @Serializable
+    data class PollResult(val id: Int = 0) : Screens
+}
 
-    fun navigateTo(navTarget: Screens) {
-        _sharedFlow.tryEmit(navTarget)
+sealed interface NavigationAction {
+    data class Navigate(
+        val destination: Screens,
+        val navOptions: NavOptionsBuilder.() -> Unit = {}
+    ) : NavigationAction
+
+    data object NavigateUp : NavigationAction
+}
+
+interface Navigator {
+    val startDestination: Screens
+    val navigationAction: Flow<NavigationAction>
+
+    suspend fun navigateTo(
+        destination: Screens,
+        navOptions: NavOptionsBuilder.() -> Unit = {}
+    )
+
+    suspend fun navigateUp()
+}
+
+class DefaultNavigator(
+    override val startDestination: Screens,
+) : Navigator {
+    private val _navigationAction = Channel<NavigationAction>()
+    override val navigationAction: Flow<NavigationAction> = _navigationAction.receiveAsFlow()
+
+    override suspend fun navigateTo(
+        destination: Screens,
+        navOptions: NavOptionsBuilder.() -> Unit
+    ) {
+        _navigationAction.send(
+            NavigationAction.Navigate(
+                destination = destination,
+                navOptions = navOptions
+            )
+        )
+    }
+
+    override suspend fun navigateUp() {
+        _navigationAction.send(NavigationAction.NavigateUp)
     }
 }
 
-@Serializable
-sealed class Screens {
-    @Serializable data object Home: Screens()
-    @Serializable data object Settings: Screens()
-    @Serializable data object About: Screens()
-    @Serializable data class PollSetup(val config: PollConfig? = null): Screens()
-    @Serializable data class PollVote(val pollId: Int) :Screens()
-    @Serializable data class PollResult(val poll: Poll) : Screens()
-}
+/**
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ */
 
 object CustomNavType {
 

--- a/app/src/main/java/com/illiouchine/jm/ui/screen/PollResultScreen.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/screen/PollResultScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -25,24 +24,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.illiouchine.jm.R
 import com.illiouchine.jm.logic.PollResultViewModel
-import com.illiouchine.jm.model.Ballot
-import com.illiouchine.jm.model.Grading
-import com.illiouchine.jm.model.Judgment
-import com.illiouchine.jm.model.Poll
-import com.illiouchine.jm.model.PollConfig
-import com.illiouchine.jm.ui.Navigator
 import com.illiouchine.jm.ui.composable.BallotCountRow
 import com.illiouchine.jm.ui.composable.LinearMeritProfileCanvas
 import com.illiouchine.jm.ui.composable.MjuSnackbar
 import com.illiouchine.jm.ui.composable.PollSubject
-import com.illiouchine.jm.ui.theme.JmTheme
 import com.illiouchine.jm.ui.utils.smoothStep
 import kotlin.math.max
 import kotlin.math.min
@@ -205,6 +196,7 @@ fun ResultScreen(
 @Preview(showSystemUi = true)
 @Composable
 fun PreviewResultScreen(modifier: Modifier = Modifier) {
+    /*
     val poll = Poll(
         pollConfig = PollConfig(
             subject = "Who for Prézidaaanh ?",
@@ -247,4 +239,5 @@ fun PreviewResultScreen(modifier: Modifier = Modifier) {
             state = state,
         )
     }
+    */
 }

--- a/app/src/main/java/com/illiouchine/jm/ui/screen/PollVotingScreen.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/screen/PollVotingScreen.kt
@@ -27,7 +27,6 @@ import com.illiouchine.jm.logic.PollVotingViewModel
 import com.illiouchine.jm.model.Ballot
 import com.illiouchine.jm.model.Grading
 import com.illiouchine.jm.model.Judgment
-import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.model.PollConfig
 import com.illiouchine.jm.ui.composable.BallotCountRow
 import com.illiouchine.jm.ui.composable.GradeSelectionList
@@ -46,7 +45,7 @@ fun PollVotingScreen(
     onBallotConfirmed: (Context, Ballot) -> Unit = { _, _ -> },
     onBallotCanceled: () -> Unit = {},
     onCancelLastJudgment: () -> Unit = {},
-    onFinish: (Poll) -> Unit = {},
+    onFinish: () -> Unit = {},
     feedback: String? = "",
     onDismissFeedback: () -> Unit = {},
 ) {
@@ -108,13 +107,7 @@ fun PollVotingScreen(
                 OutlinedButton(
                     modifier = Modifier.align(Alignment.CenterHorizontally),
                     enabled = pollVotingState.ballots.isNotEmpty(),
-                    onClick = {
-                        val poll = Poll(
-                            pollConfig = pollVotingState.pollConfig,
-                            ballots = pollVotingState.ballots,
-                        )
-                        onFinish(poll)
-                    },
+                    onClick = { onFinish() },
                 ) { Text(stringResource(R.string.button_end_the_poll)) }
             } else {
 

--- a/app/src/main/java/com/illiouchine/jm/ui/utils/ObserveAsEvents.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/utils/ObserveAsEvents.kt
@@ -1,0 +1,30 @@
+package com.illiouchine.jm.ui.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+
+@Composable
+fun <T> ObserveAsEvents(
+    flow: Flow<T>,
+    key1: Any? = null,
+    key2: Any? = null,
+    onEvent: (T) -> Unit
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(
+        key1 = lifecycleOwner.lifecycle,
+        key1, key2
+    ) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            withContext(Dispatchers.Main.immediate) {
+                flow.collect(onEvent)
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Use typeSafe navigation.
- Better handling navigation event
- Use method reference instead of lambda to avoid useless recomposition