### PR TITLE
Add two safeguards against inspecting empty polls

### DIFF
--- a/app/src/main/java/com/illiouchine/jm/ui/composable/PollSummary.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/composable/PollSummary.kt
@@ -84,7 +84,10 @@ fun PollSummary(
                 TextButton(onClick = { onResumePoll(poll) }) {
                     Text(stringResource(R.string.action_resume))
                 }
-                TextButton(onClick = { onShowResult(poll) }) {
+                TextButton(
+                    enabled = poll.ballots.isNotEmpty(),
+                    onClick = { onShowResult(poll) },
+                ) {
                     Text(stringResource(R.string.action_inspect))
                 }
             }


### PR DESCRIPTION
- [x] The result screen does not crash anymore
- [x] The Inspect button on the Home becomes disabled