### PR TITLE
Show the relative neutral on the proximity spider plots

### DIFF
--- a/app/src/main/java/com/illiouchine/jm/ui/composable/plot/ProximitySpider.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/composable/plot/ProximitySpider.kt
@@ -40,6 +40,13 @@ fun ProximitySpider(
 ) {
     val proposalsInitials = makeProposalsInitials(analysis)
 
+    val neutral = analysis.neutrals[selectedProposalIndex]
+    val tickValues = buildList {
+        add(-1f)
+        add(neutral.toFloat())
+        add(1f)
+    }
+
     SpiderChart(
         modifier = modifier,
         title = {
@@ -56,8 +63,8 @@ fun ProximitySpider(
         // categories = filteredAnalysis.proposals.map { it.truncate(16, "…") },
         categories = proposalsInitials, // so we use initials, it worked nicely so far
         values = analysis.proximities[selectedProposalIndex].map { it.toFloat() },
-        tickValues = listOf(-1f, 0f, 1f),
-        tickDecimals = 0,
+        tickValues = tickValues,
+        tickDecimals = 2,
         highlightedCategoryIndex = selectedProposalIndex,
         onCategoryClick = onProposalSelected,
     )

--- a/app/src/main/java/com/illiouchine/jm/ui/composable/plot/lib/SpiderChart.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/composable/plot/lib/SpiderChart.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.illiouchine.jm.extensions.smartFormat
 import com.illiouchine.jm.ui.composable.plot.component.PlotTitle
 import com.illiouchine.jm.ui.theme.JmTheme
 import com.illiouchine.jm.ui.theme.Theme
@@ -33,7 +34,6 @@ import io.github.koalaplot.core.polar.rememberFloatRadialAxisModel
 import io.github.koalaplot.core.style.AreaStyle
 import io.github.koalaplot.core.style.LineStyle
 import io.github.koalaplot.core.util.ExperimentalKoalaPlotApi
-import ir.ehsannarmani.compose_charts.extensions.format
 
 @OptIn(ExperimentalKoalaPlotApi::class)
 @Composable
@@ -44,7 +44,7 @@ fun SpiderChart(
     categories: List<String>,
     values: List<Float>,
     tickValues: List<Float> = listOf(-1f, 0f, 1f),
-    tickDecimals: Int = 0,
+    tickDecimals: Int = 1,
     highlightedCategoryIndex: Int = -1,
     onCategoryClick: (categoryIndex: Int) -> Unit = {},
 ) {
@@ -76,7 +76,7 @@ fun SpiderChart(
             angularAxisModel = rememberCategoryAngularAxisModel(indexedCategories),
             radialAxisLabels = {
                 Text(
-                    text = it.toDouble().format(tickDecimals),
+                    text = it.toDouble().smartFormat(tickDecimals),
                     style = TextStyle.Default,
                 )
             },

--- a/metadata/en-GB/changelogs/21.txt
+++ b/metadata/en-GB/changelogs/21.txt
@@ -1,2 +1,4 @@
 * Add Aye/Meh/Nay grading
 * Allow filtering ballots by nuance
+* Add the Breton language
+* Show the relative neutral on the proximity spider plots

--- a/metadata/en-US/changelogs/21.txt
+++ b/metadata/en-US/changelogs/21.txt
@@ -1,2 +1,4 @@
 * Add Aye/Meh/Nay grading
 * Allow filtering ballots by nuance
+* Add the Breton language
+* Show the relative neutral on the proximity spider plots

--- a/metadata/fr-FR/changelogs/21.txt
+++ b/metadata/fr-FR/changelogs/21.txt
@@ -1,2 +1,4 @@
 * Ajout des mentions Oui/Bof/Non
 * Filtre sur les bulletins par nuance
+* Ajout du Breton
+* Affichage du neutral relatif sur les toiles de proximité


### PR DESCRIPTION
It makes much more sense to show the relative neutral than the zero, which is the absolute neutral. The relative neutral is more meaningful, I believe.

To recap here, the relative neutral is the proximity value that is indistinguishable from random.
In other words, it's the average proximity value with other merit profiles chosen at random.

Fix #230 