### PR TITLE
Refactor QR code URL generation and parsing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,13 +60,6 @@ android {
     buildFeatures {
         compose = true
     }
-    packaging {
-        // For org.apache.arrow:arrow-dataset:18.3.0 and 6 others (from dataframe)
-        // dataframe is too big, so it has been removed for now, hence the comments
-//        resources.excludes.add("META-INF/DEPENDENCIES")
-//        resources.excludes.add("META-INF/*LICENSE")
-//        resources.excludes.add("META-INF/*NOTICE")
-    }
 
     room {
         schemaDirectory("$projectDir/schemas")
@@ -147,7 +140,6 @@ dependencies {
     ksp(libs.androidx.room.compiler)
 
     // Plotting
-    //implementation(libs.kandy.lets.plot) // not using kandy for now as it produces raster (+svg)
     implementation(libs.compose.charts)
     implementation(libs.koalaplot.core)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
         minSdk = 27
         targetSdk = 35
         // You need to bump both of these versions when making a new release.
-        versionCode = 23
-        versionName = "1.6.1"
+        versionCode = 24
+        versionName = "1.6.2"
 
         // Ideally we'd have both, but support for multiple runners looks experimental
 //        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,6 +133,7 @@ dependencies {
     implementation(project.dependencies.platform(libs.koin.bom))
     implementation(libs.koin.core)
     implementation(libs.koin.android)
+    implementation(libs.koin.compose)
 
     // Room (Database)
     implementation(libs.androidx.room.runtime)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,14 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <!--
+            ## Solution 1
+            The mju:// scheme will only work on recent Android versions.
+            It does not work on my Android 13 device, for example.  T_T
+            It's also not recommended to use a custom scheme.
+            But, it does work on recent Android devices, fully offline, so that's nice.
+            Also, it's short.
+            -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -33,6 +41,19 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="mju" android:host="b" />
+            </intent-filter>
+            <!--
+            ## Solution 2
+            As is recommended, we can use the https scheme and a domain we own.
+            Hmmm…  Maybe not.  Android needs a network call to verify the domain.
+            This sucks, as this app is expected to work 100% offline.
+            Also, we have not deployed (yet) the .well-known on the server.
+            -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="mju.mieuxvoter.fr" />
             </intent-filter>
         </activity>
         <provider

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
@@ -8,8 +7,8 @@
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
-        android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Jm"
@@ -23,27 +22,30 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <!--
-            ## Solution 1
-            The mju:// scheme will only work on recent Android versions.
+            ## Solution 1: Custom Deep Links
+            The mju:// scheme will only work on Android versions before 12.
             It does not work on my Android 13 device, for example.  T_T
-            It's also not recommended to use a custom scheme.
-            But, it does work on recent Android devices, fully offline, so that's nice.
-            Also, it's short.
+            It's not recommended to use a custom scheme, and so Google disabled it.
+            But it's shorter, and it used to work 100% offline.
             -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="mju" android:host="p" />
+                <data
+                    android:host="p"
+                    android:scheme="mju" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="mju" android:host="b" />
+                <data
+                    android:host="b"
+                    android:scheme="mju" />
             </intent-filter>
             <!--
-            ## Solution 2
+            ## Solution 2: Deep App Links
             As is recommended, we can use the https scheme and a domain we own.
             Hmmm…  Maybe not.  Android needs a network call to verify the domain.
             This sucks, as this app is expected to work 100% offline.
@@ -53,7 +55,19 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https" android:host="mju.mieuxvoter.fr" />
+                <data
+                    android:host="mju.mieuxvoter.fr"
+                    android:pathPrefix="/p"
+                    android:scheme="https" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:host="mju.mieuxvoter.fr"
+                    android:pathPrefix="/b"
+                    android:scheme="https" />
             </intent-filter>
         </activity>
         <provider

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,9 +47,10 @@
             <!--
             ## Solution 2: Deep App Links
             As is recommended, we can use the https scheme and a domain we own.
-            Hmmm…  Maybe not.  Android needs a network call to verify the domain.
+            Android needs a network call to verify the domain (at install time).
             This sucks, as this app is expected to work 100% offline.
-            Also, we have not deployed (yet) the .well-known on the server.
+            We deployed the relevant file at:
+            https://mju.mieuxvoter.fr/.well-known/assetlinks.json
             -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/java/com/illiouchine/jm/MainActivity.kt
+++ b/app/src/main/java/com/illiouchine/jm/MainActivity.kt
@@ -39,6 +39,7 @@ import com.illiouchine.jm.logic.PollResultViewModel
 import com.illiouchine.jm.logic.PollSetupViewModel
 import com.illiouchine.jm.logic.PollVotingViewModel
 import com.illiouchine.jm.logic.SettingsViewModel
+import com.illiouchine.jm.service.ExchangeUriService
 import com.illiouchine.jm.ui.navigator.Screens
 import com.illiouchine.jm.ui.navigator.TopLevelBackStack
 import com.illiouchine.jm.ui.screen.AboutScreen
@@ -55,9 +56,12 @@ import com.illiouchine.jm.ui.screen.ProportionsHelpScreen
 import com.illiouchine.jm.ui.screen.ResultScreen
 import com.illiouchine.jm.ui.screen.SettingsScreen
 import com.illiouchine.jm.ui.theme.JmTheme
+import org.koin.android.ext.android.get
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class MainActivity : ComponentActivity() {
+
+    private val exchangeUriService: ExchangeUriService = get()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -94,32 +98,49 @@ class MainActivity : ComponentActivity() {
                         // Toast.makeText(context, uri.host, Toast.LENGTH_LONG).show()
                         // Toast.makeText(context, uri.path, Toast.LENGTH_LONG).show()
 
-                        if (uri.host == "p") {
-                            // p is for Poll ; let's import the poll if we can
-                            val data = uri.path
-                            if (data != null) {
-                                val compressedDataString = data.substring(1)
-                                topLevelBackStack.add(
-                                    Screens.PollQrImport(
-                                        encodedContent = compressedDataString,
-                                    )
+//                        if (uri.host == "p") {
+//                            // CUSTOM SCHEME URL FORMAT mju://p/<gnagnagna>
+//                            // p is for Poll ; let's import the poll if we can
+//                            val data = uri.path
+//                            if (data != null) {
+//                                val compressedDataString = data.substring(1)
+//                                topLevelBackStack.add(
+//                                    Screens.PollQrImport(
+//                                        encodedContent = compressedDataString,
+//                                    )
+//                                )
+//                            }
+//                        } else if (uri.host == "b") {
+//                            // CUSTOM SCHEME URL FORMAT mju://b/<gnagnagna>
+//                            // b is for Ballots ; let's import the ballots if we can
+//                            val data = uri.path
+//                            if (data != null) {
+//                                val compressedDataString = data.substring(1)
+//                                topLevelBackStack.add(
+//                                    Screens.BallotsQrImport(
+//                                        encodedContent = compressedDataString,
+//                                    )
+//                                )
+//                            }
+//                        } else
+                        if (exchangeUriService.uriMatchesPoll(uri)) {
+                            val compressedDataString = uri.pathSegments[1]
+                            topLevelBackStack.add(
+                                Screens.PollQrImport(
+                                    encodedContent = compressedDataString,
                                 )
-                            }
-                        } else if (uri.host == "b") {
-                            // b is for Ballots ; let's import the ballots if we can
-                            val data = uri.path
-                            if (data != null) {
-                                val compressedDataString = data.substring(1)
-                                topLevelBackStack.add(
-                                    Screens.BallotsQrImport(
-                                        encodedContent = compressedDataString,
-                                    )
+                            )
+                        } else if (exchangeUriService.uriMatchesBallots(uri)) {
+                            val compressedDataString = uri.pathSegments[1]
+                            topLevelBackStack.add(
+                                Screens.BallotsQrImport(
+                                    encodedContent = compressedDataString,
                                 )
-                            }
+                            )
                         } else {
                             Toast.makeText(
                                 context,
-                                "Error: unsupported URI host.",
+                                "Error: unsupported URI.",
                                 Toast.LENGTH_LONG,
                             ).show()
                         }
@@ -343,7 +364,7 @@ class MainActivity : ComponentActivity() {
                             LaunchedEffect(key.encodedContent) {
                                 viewModel.initialize(
                                     context = context,
-                                    qrUriPath = key.encodedContent,
+                                    qrUriPathDatum = key.encodedContent,
                                 )
                             }
 
@@ -402,7 +423,7 @@ class MainActivity : ComponentActivity() {
                             LaunchedEffect(key.encodedContent) {
                                 viewModel.initialize(
                                     context = context,
-                                    qrUriPath = key.encodedContent,
+                                    qrUriPathDatum = key.encodedContent,
                                 )
                             }
 

--- a/app/src/main/java/com/illiouchine/jm/MainActivity.kt
+++ b/app/src/main/java/com/illiouchine/jm/MainActivity.kt
@@ -98,40 +98,15 @@ class MainActivity : ComponentActivity() {
                         // Toast.makeText(context, uri.host, Toast.LENGTH_LONG).show()
                         // Toast.makeText(context, uri.path, Toast.LENGTH_LONG).show()
 
-//                        if (uri.host == "p") {
-//                            // CUSTOM SCHEME URL FORMAT mju://p/<gnagnagna>
-//                            // p is for Poll ; let's import the poll if we can
-//                            val data = uri.path
-//                            if (data != null) {
-//                                val compressedDataString = data.substring(1)
-//                                topLevelBackStack.add(
-//                                    Screens.PollQrImport(
-//                                        encodedContent = compressedDataString,
-//                                    )
-//                                )
-//                            }
-//                        } else if (uri.host == "b") {
-//                            // CUSTOM SCHEME URL FORMAT mju://b/<gnagnagna>
-//                            // b is for Ballots ; let's import the ballots if we can
-//                            val data = uri.path
-//                            if (data != null) {
-//                                val compressedDataString = data.substring(1)
-//                                topLevelBackStack.add(
-//                                    Screens.BallotsQrImport(
-//                                        encodedContent = compressedDataString,
-//                                    )
-//                                )
-//                            }
-//                        } else
                         if (exchangeUriService.uriMatchesPoll(uri)) {
-                            val compressedDataString = uri.pathSegments[1]
+                            val compressedDataString = uri.pathSegments.last()
                             topLevelBackStack.add(
                                 Screens.PollQrImport(
                                     encodedContent = compressedDataString,
                                 )
                             )
                         } else if (exchangeUriService.uriMatchesBallots(uri)) {
-                            val compressedDataString = uri.pathSegments[1]
+                            val compressedDataString = uri.pathSegments.last()
                             topLevelBackStack.add(
                                 Screens.BallotsQrImport(
                                     encodedContent = compressedDataString,

--- a/app/src/main/java/com/illiouchine/jm/MajorityUrnApplication.kt
+++ b/app/src/main/java/com/illiouchine/jm/MajorityUrnApplication.kt
@@ -19,6 +19,7 @@ import com.illiouchine.jm.logic.PollResultViewModel
 import com.illiouchine.jm.logic.PollSetupViewModel
 import com.illiouchine.jm.logic.PollVotingViewModel
 import com.illiouchine.jm.logic.SettingsViewModel
+import com.illiouchine.jm.service.ExchangeUriService
 import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
@@ -36,7 +37,7 @@ class MajorityUrnApplication : Application() {
 }
 
 val module = module {
-    // DataBase
+    // Database
     single {
         Room.databaseBuilder(
             context = androidApplication(),
@@ -55,7 +56,20 @@ val module = module {
     single<PollDataSource> { SqlitePollDataSource(get()) }
     single<PollTemplateDataSource> { HardcodedPollTemplateDataSource() }
 
-    // ViewModel
+    // Miscellaneous
+    single {
+        ExchangeUriService(
+            scheme = "mju",
+            domain = "",
+            // We'll get back to the https scheme later ; perhaps using another service?
+//            scheme = "https",
+//            domain = "mju.mieuxvoter.fr",
+            pollRoutePathSegment = "p",
+            ballotsRoutePathSegment = "b",
+        )
+    }
+
+    // ViewModels
     viewModel {
         HomeViewModel(
             pollDataSource = get(),
@@ -92,21 +106,25 @@ val module = module {
     viewModel {
         PollQrExportViewModel(
             pollDataSource = get(),
+            exchangeUriService = get(),
         )
     }
     viewModel {
         PollQrImportViewModel(
             pollDataSource = get(),
+            exchangeUriService = get(),
         )
     }
     viewModel {
         BallotsQrExportViewModel(
             pollDataSource = get(),
+            exchangeUriService = get(),
         )
     }
     viewModel {
         BallotsQrImportViewModel(
             pollDataSource = get(),
+            exchangeUriService = get(),
         )
     }
     viewModel {

--- a/app/src/main/java/com/illiouchine/jm/MajorityUrnApplication.kt
+++ b/app/src/main/java/com/illiouchine/jm/MajorityUrnApplication.kt
@@ -59,11 +59,12 @@ val module = module {
     // Miscellaneous
     single {
         ExchangeUriService(
-            scheme = "mju",
-            domain = "",
-            // We'll get back to the https scheme later ; perhaps using another service?
-//            scheme = "https",
-//            domain = "mju.mieuxvoter.fr",
+            // Legacy mju:// scheme
+//            scheme = "mju",
+//            domain = "",
+            // Using the https:// scheme
+            scheme = "https",
+            domain = "mju.mieuxvoter.fr",
             pollRoutePathSegment = "p",
             ballotsRoutePathSegment = "b",
         )

--- a/app/src/main/java/com/illiouchine/jm/config/ProportionalAlgorithms.kt
+++ b/app/src/main/java/com/illiouchine/jm/config/ProportionalAlgorithms.kt
@@ -102,17 +102,21 @@ enum class ProportionalAlgorithms {
      */
     abstract fun getDescription(context: Context): String
 
+    /**
+     * Additional content shown on the help screen, describing the features of the algorithm.
+     */
     abstract fun getFeatures(context: Context): String
 
     /**
      * Whether this algorithm is available to users.
+     * Nowadays all the algorithms are available, but in the past some used to be hidden.
      */
     abstract fun isAvailable(): Boolean
 
     /**
      * The output list is sorted in order of the input proposals.
      * It ought to be normalized (the sum of its elements must be 1.0).
-     * Except for NONE, where the list might be empty (or full of zeros).
+     * Except for NONE, where the list might be empty (or full of meaningless values).
      */
     abstract fun compute(poll: Poll, result: ResultInterface): List<Double>
 }

--- a/app/src/main/java/com/illiouchine/jm/filters/README.md
+++ b/app/src/main/java/com/illiouchine/jm/filters/README.md
@@ -1,0 +1,23 @@
+# Ballot Filters
+
+Ballot filters are used for deep analysis.
+
+They are useful to see what some subsets of voters think.
+
+For example:
+
+- what is the opinion on other candidates of voters that think some candidate to be excellent ?
+- what is the opinion of voters that vote without nuance ?
+
+These analyses are extremely useful to (political) candidates.
+
+
+## Fingerprinting Issues
+
+Sadly, the ballot filters require access to the ballots, not just the merit profiles.
+
+This is a little bit problematic because it somewhat helps coercition, by fingerprinting ballots.
+
+We can get away with it in this app because of the low stakes of the polls.
+
+

--- a/app/src/main/java/com/illiouchine/jm/logic/BallotsQrExportViewModel.kt
+++ b/app/src/main/java/com/illiouchine/jm/logic/BallotsQrExportViewModel.kt
@@ -8,13 +8,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.illiouchine.jm.R
 import com.illiouchine.jm.data.PollDataSource
-import com.illiouchine.jm.model.Ballot
 import com.illiouchine.jm.model.Poll
-import com.illiouchine.jm.model.serializer.UUIDSerializer
+import com.illiouchine.jm.model.dto.BallotsDto
+import com.illiouchine.jm.service.ExchangeUriService
 import com.illiouchine.jm.ui.navigator.NavigationAction
 import com.illiouchine.jm.ui.navigator.Screens
-import com.illiouchine.jm.ui.utils.compress
-import com.illiouchine.jm.ui.utils.encode
 import com.illiouchine.jm.ui.utils.imageBitmapFromPngBytes
 import com.illiouchine.jm.ui.utils.renderQrCodePngBytes
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -24,51 +22,11 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.cbor.Cbor
-import kotlinx.serialization.encodeToByteArray
-import java.util.UUID
-import kotlin.math.min
-
-@Stable
-@Serializable
-/**
- * This Data Transfer Object is what's encoded in the QR Code.
- */
-data class BallotsDto(
-    @Serializable(UUIDSerializer::class)
-    val pollUuid: UUID,
-    val ballots: List<Ballot>,
-) {
-    fun splitInto(amountOfPieces: Int): List<BallotsDto> {
-        val amountOfBallots = this.ballots.size
-
-        require(amountOfPieces > 0)
-        require(amountOfPieces <= amountOfBallots)
-
-        val rabiot = if (amountOfBallots % amountOfPieces == 0) { 0 } else { 1 }
-        val share = amountOfBallots / amountOfPieces + rabiot // Euclid, mah man
-        return buildList {
-            for (i in 0..<amountOfPieces) {
-                add(
-                    copy(
-                        ballots = ballots.subList(
-                            i * share,
-                            min(
-                                amountOfBallots,
-                                (i + 1) * share,
-                            ),
-                        ),
-                    )
-                )
-            }
-        }
-    }
-}
 
 class BallotsQrExportViewModel(
     private val pollDataSource: PollDataSource,
+    private val exchangeUriService: ExchangeUriService,
 ) : ViewModel() {
 
     @Stable
@@ -78,19 +36,19 @@ class BallotsQrExportViewModel(
          */
         val ballotsDto: BallotsDto? = null,
         /**
-         * Full content of the QR Code, including the URL prefix (host+domain).
+         * Full content of the QR Code, including the URL prefix (scheme+domain+path).
          */
         val qrContent: String? = null,
         val qrBitmap: ImageBitmap? = null,
     ) {
-        companion object {
+        companion object { // cheap factories
             @OptIn(ExperimentalSerializationApi::class)
-            fun createFromBallotsDto(ballotsDto: BallotsDto): BallotsQrExport? {
+            fun createFromBallotsDto(
+                exchangeUriService: ExchangeUriService,
+                ballotsDto: BallotsDto,
+            ): BallotsQrExport? {
                 try {
-                    val ballotsBytes = Cbor.encodeToByteArray(value = ballotsDto)
-                    val ballotsCompressedBytes = compress(input = ballotsBytes)
-                    val ballotsCompressedString = encode(bytes = ballotsCompressedBytes)
-                    val qrContent = "mju://b/$ballotsCompressedString"
+                    val qrContent = exchangeUriService.ballotsDtoToUri(ballotsDto)
                     val qrPngBytes = renderQrCodePngBytes(qrContent)
                     val qrBitmap = imageBitmapFromPngBytes(qrPngBytes)
                     return BallotsQrExport(
@@ -107,7 +65,10 @@ class BallotsQrExportViewModel(
             }
         }
 
-        fun splitIfNecessary(maxAmountOfBytes: Int = 650): List<BallotsQrExport> {
+        fun splitIfNecessary(
+            exchangeUriService: ExchangeUriService,
+            maxAmountOfBytes: Int = 650,
+        ): List<BallotsQrExport> {
             if (this.qrContent == null) {
                 return listOf(this)
             }
@@ -119,7 +80,10 @@ class BallotsQrExportViewModel(
             val ballotsDtos = this.ballotsDto.splitInto(amountOfQrCodes)
             return buildList {
                 for (i in 0..<amountOfQrCodes) {
-                    val ballotsQrExport = createFromBallotsDto(ballotsDto = ballotsDtos[i])
+                    val ballotsQrExport = createFromBallotsDto(
+                        exchangeUriService = exchangeUriService,
+                        ballotsDto = ballotsDtos[i],
+                    )
                     if (ballotsQrExport != null) {
                         add(ballotsQrExport)
                     }
@@ -188,13 +152,21 @@ class BallotsQrExportViewModel(
             ballots = poll.ballots,
         )
 
-        val qrExport = BallotsQrExport.createFromBallotsDto(ballotsDto)
+        val qrExport = BallotsQrExport.createFromBallotsDto(
+            exchangeUriService = exchangeUriService,
+            ballotsDto = ballotsDto,
+        )
+
+        val qrExports = qrExport?.splitIfNecessary(
+            exchangeUriService = exchangeUriService,
+            maxAmountOfBytes = 650,
+        )
 
         _viewState.update {
             it.copy(
                 poll = poll,
                 errorMessage = null,
-                qrExports = qrExport?.splitIfNecessary(650) ?: emptyList(),
+                qrExports = qrExports ?: emptyList(),
             )
         }
     }

--- a/app/src/main/java/com/illiouchine/jm/logic/BallotsQrImportViewModel.kt
+++ b/app/src/main/java/com/illiouchine/jm/logic/BallotsQrImportViewModel.kt
@@ -7,23 +7,21 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.illiouchine.jm.data.PollDataSource
 import com.illiouchine.jm.model.Poll
+import com.illiouchine.jm.model.dto.BallotsDto
+import com.illiouchine.jm.service.ExchangeUriService
 import com.illiouchine.jm.ui.navigator.NavigationAction
-import com.illiouchine.jm.ui.utils.decode
-import com.illiouchine.jm.ui.utils.decompress
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.cbor.Cbor
-import kotlinx.serialization.decodeFromByteArray
 import java.util.zip.DataFormatException
 
 class BallotsQrImportViewModel(
     private val pollDataSource: PollDataSource,
+    private val exchangeUriService: ExchangeUriService,
 ) : ViewModel() {
 
     @Stable
@@ -41,22 +39,19 @@ class BallotsQrImportViewModel(
     private val _navEvents = MutableSharedFlow<NavigationAction>()
     val navEvents = _navEvents.asSharedFlow()
 
-    @OptIn(ExperimentalSerializationApi::class)
     fun initialize(
         context: Context,
-        qrUriPath: String,
+        qrUriPathDatum: String,
     ) {
 //        viewModelScope.launch {
         _viewState.update {
             ViewState(
-                qrUriPath = qrUriPath,
+                qrUriPath = qrUriPathDatum,
             )
         }
 
         try {
-            val compressedPollString = decode(qrUriPath)
-            val decompressedQrBytes = decompress(compressedPollString)
-            val ballotsDto = Cbor.decodeFromByteArray<BallotsDto>(decompressedQrBytes)
+            val ballotsDto = exchangeUriService.uriPathDatumToBallotsDto(qrUriPathDatum)
             initializeFromBallotsDto(
                 // context = context,
                 ballotsDto = ballotsDto,

--- a/app/src/main/java/com/illiouchine/jm/logic/PollQrExportViewModel.kt
+++ b/app/src/main/java/com/illiouchine/jm/logic/PollQrExportViewModel.kt
@@ -10,10 +10,9 @@ import com.illiouchine.jm.R
 import com.illiouchine.jm.data.PollDataSource
 import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.model.PollConfig
+import com.illiouchine.jm.service.ExchangeUriService
 import com.illiouchine.jm.ui.navigator.NavigationAction
 import com.illiouchine.jm.ui.navigator.Screens
-import com.illiouchine.jm.ui.utils.compress
-import com.illiouchine.jm.ui.utils.encode
 import com.illiouchine.jm.ui.utils.imageBitmapFromPngBytes
 import com.illiouchine.jm.ui.utils.renderQrCodePngBytes
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -23,11 +22,10 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.cbor.Cbor
-import kotlinx.serialization.encodeToByteArray
 
 class PollQrExportViewModel(
     private val pollDataSource: PollDataSource,
+    private val exchangeUriService: ExchangeUriService,
 ) : ViewModel() {
 
     @Stable
@@ -65,6 +63,7 @@ class PollQrExportViewModel(
             val poll = pollDataSource.getPollById(pollId)
 
             if (poll == null) {
+                // TBD: We should NOT toast & redirect in here, but return an error code
                 Toast.makeText(
                     context,
                     context.getString(R.string.toast_that_poll_does_not_exist),
@@ -73,7 +72,6 @@ class PollQrExportViewModel(
                 _navEvents.emit(NavigationAction.To(Screens.Home))
             } else {
                 initializeFromPoll(
-                    // context = context,
                     poll = poll,
                 )
             }
@@ -82,15 +80,9 @@ class PollQrExportViewModel(
 
     @OptIn(ExperimentalSerializationApi::class)
     fun initializeFromPoll(
-        // context: Context,
         poll: Poll,
     ) {
-        val pollToExport = poll.copy(id = 0, ballots = emptyList())
-        val pollBytes = Cbor.encodeToByteArray(pollToExport)
-        val compressedPollBytes = compress(pollBytes)
-        val compressedPollString = encode(compressedPollBytes)
-        val qrContent = "mju://p/$compressedPollString"
-
+        val qrContent = exchangeUriService.pollToUri(poll)
         // Up to 2,953 bytes (so the spec says ; we need to check, seems less)
         val qrPngBytes = renderQrCodePngBytes(qrContent)
         val qrBitmap = imageBitmapFromPngBytes(qrPngBytes)

--- a/app/src/main/java/com/illiouchine/jm/logic/PollQrImportViewModel.kt
+++ b/app/src/main/java/com/illiouchine/jm/logic/PollQrImportViewModel.kt
@@ -6,23 +6,20 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.illiouchine.jm.data.PollDataSource
 import com.illiouchine.jm.model.Poll
+import com.illiouchine.jm.service.ExchangeUriService
 import com.illiouchine.jm.ui.navigator.NavigationAction
-import com.illiouchine.jm.ui.utils.decode
-import com.illiouchine.jm.ui.utils.decompress
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.cbor.Cbor
-import kotlinx.serialization.decodeFromByteArray
 import java.util.zip.DataFormatException
 
 class PollQrImportViewModel(
     private val pollDataSource: PollDataSource,
+    private val exchangeUriService: ExchangeUriService,
 ) : ViewModel() {
 
     @Stable
@@ -40,22 +37,19 @@ class PollQrImportViewModel(
     private val _navEvents = MutableSharedFlow<NavigationAction>()
     val navEvents = _navEvents.asSharedFlow()
 
-    @OptIn(ExperimentalSerializationApi::class)
     fun initialize(
         context: Context,
-        qrUriPath: String,
+        qrUriPathDatum: String,
     ) {
 //        viewModelScope.launch {
         _viewState.update {
             PollQrImportViewState(
-                qrUriPath = qrUriPath,
+                qrUriPath = qrUriPathDatum,
             )
         }
 
         try {
-            val compressedPollString = decode(qrUriPath)
-            val decompressedQrBytes = decompress(compressedPollString)
-            val poll = Cbor.decodeFromByteArray<Poll>(decompressedQrBytes)
+            val poll = exchangeUriService.uriPathDatumToPoll(qrUriPathDatum)
             initializeFromPoll(context, poll)
         } catch (e: DataFormatException) {
             _viewState.update {

--- a/app/src/main/java/com/illiouchine/jm/model/dto/BallotsDto.kt
+++ b/app/src/main/java/com/illiouchine/jm/model/dto/BallotsDto.kt
@@ -1,0 +1,44 @@
+package com.illiouchine.jm.model.dto
+
+import androidx.compose.runtime.Stable
+import com.illiouchine.jm.model.Ballot
+import com.illiouchine.jm.model.serializer.UUIDSerializer
+import kotlinx.serialization.Serializable
+import java.util.UUID
+import kotlin.math.min
+
+@Stable
+@Serializable
+/**
+ * This lightweight Data Transfer Object is what's encoded in the QR Code.
+ */
+data class BallotsDto(
+    @Serializable(UUIDSerializer::class)
+    val pollUuid: UUID,
+    val ballots: List<Ballot>,
+) {
+    fun splitInto(amountOfPieces: Int): List<BallotsDto> {
+        val amountOfBallots = this.ballots.size
+
+        require(amountOfPieces > 0)
+        require(amountOfPieces <= amountOfBallots)
+
+        val rabiot = if (amountOfBallots % amountOfPieces == 0) { 0 } else { 1 }
+        val share = amountOfBallots / amountOfPieces + rabiot // Euclid, mah man
+        return buildList {
+            for (i in 0..<amountOfPieces) {
+                add(
+                    copy(
+                        ballots = ballots.subList(
+                            i * share,
+                            min(
+                                amountOfBallots,
+                                (i + 1) * share,
+                            ),
+                        ),
+                    )
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/illiouchine/jm/service/ExchangeUriService.kt
+++ b/app/src/main/java/com/illiouchine/jm/service/ExchangeUriService.kt
@@ -1,0 +1,117 @@
+package com.illiouchine.jm.service
+
+import android.net.Uri
+import com.illiouchine.jm.model.Poll
+import com.illiouchine.jm.model.dto.BallotsDto
+import com.illiouchine.jm.ui.utils.compress
+import com.illiouchine.jm.ui.utils.decode
+import com.illiouchine.jm.ui.utils.decompress
+import com.illiouchine.jm.ui.utils.encode
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.cbor.Cbor
+import kotlinx.serialization.decodeFromByteArray
+import kotlinx.serialization.encodeToByteArray
+
+/**
+ * Serialization and deserialization utility for polls and their ballots.
+ * Also see the AndroidManifest.xml where the URI intent filter is declared.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+class ExchangeUriService(
+    /**
+     * Without the :// suffix.
+     * Example: https
+     */
+    private val scheme: String,
+    /**
+     * You should own this domain.  (it might need verification from Gogole)
+     * Example: mju.mieuxvoter.fr
+     */
+    private val domain: String,
+    private val pollRoutePathSegment: String = "p",
+    private val ballotsRoutePathSegment: String = "b",
+) {
+
+    fun pollToUri(
+        poll: Poll,
+    ): String {
+        // TBD: this is awkward ; we should probably use a PollDto
+        val pollToExport = poll.copy(
+            id = 0, // this identifier is local to the device, it's meaningless to exchange it
+            ballots = emptyList(), // we do not want to send the ballots, only the poll config
+        )
+        val pollBytes = Cbor.encodeToByteArray(value = pollToExport)
+        val compressedPollBytes = compress(input = pollBytes)
+        val compressedPollString = encode(bytes = compressedPollBytes)
+        return buildString {
+            append(scheme)
+            append("://")
+            if (domain.isNotEmpty()) {
+                append(domain)
+                append("/")
+            }
+            append(pollRoutePathSegment)
+            append("/")
+            append(compressedPollString)
+        }
+    }
+
+    fun ballotsDtoToUri(
+        ballotsDto: BallotsDto,
+    ): String {
+        val ballotsBytes = Cbor.encodeToByteArray(value = ballotsDto)
+        val ballotsCompressedBytes = compress(input = ballotsBytes)
+        val ballotsCompressedString = encode(bytes = ballotsCompressedBytes)
+        return buildString {
+            append(scheme)
+            append("://")
+            if (domain.isNotEmpty()) {
+                append(domain)
+                append("/")
+            }
+            append(ballotsRoutePathSegment)
+            append("/")
+            append(ballotsCompressedString)
+        }
+    }
+
+    fun uriPathDatumToPoll(
+        /**
+         * Not the full path ; only the part after the /p/, like so:
+         *     https://mju.mieuxvoter.fr/p/<uriPathDatum>
+         * This does not include the query or fragment part of the Uri (if we ever have any).
+         */
+        uriPathDatum: String,
+    ): Poll {
+        val compressedString = decode(string = uriPathDatum)
+        val decompressedBytes = decompress(input = compressedString)
+        return Cbor.decodeFromByteArray<Poll>(bytes = decompressedBytes)
+    }
+
+    fun uriPathDatumToBallotsDto(
+        /**
+         * Not the full path ; only the part after the /b/, like so:
+         *     https://mju.mieuxvoter.fr/b/<uriPathDatum>
+         * This does not include the query or fragment part of the Uri (if we ever have any).
+         */
+        uriPathDatum: String,
+    ): BallotsDto {
+        val compressedString = decode(string = uriPathDatum)
+        val decompressedBytes = decompress(input = compressedString)
+        return Cbor.decodeFromByteArray<BallotsDto>(bytes = decompressedBytes)
+    }
+
+    fun uriMatchesFormat(uri: Uri): Boolean {
+        return uriMatchesHost(uri) && uri.pathSegments.size == 2
+    }
+    fun uriMatchesHost(uri: Uri): Boolean {
+        return uri.scheme == scheme && uri.host == domain
+    }
+    fun uriMatchesPoll(uri: Uri): Boolean {
+        return uriMatchesFormat(uri) && uri.pathSegments.first() == pollRoutePathSegment
+    }
+    fun uriMatchesBallots(uri: Uri): Boolean {
+        return uriMatchesFormat(uri) && uri.pathSegments.first() == ballotsRoutePathSegment
+    }
+
+}

--- a/app/src/main/java/com/illiouchine/jm/service/ExchangeUriService.kt
+++ b/app/src/main/java/com/illiouchine/jm/service/ExchangeUriService.kt
@@ -26,6 +26,7 @@ class ExchangeUriService(
     /**
      * You should own this domain.  (it might need verification from Gogole)
      * Example: mju.mieuxvoter.fr
+     * Note: this is allowed to be empty, in the case where we use our custom mju:// scheme.
      */
     private val domain: String,
     private val pollRoutePathSegment: String = "p",
@@ -101,17 +102,24 @@ class ExchangeUriService(
         return Cbor.decodeFromByteArray<BallotsDto>(bytes = decompressedBytes)
     }
 
-    fun uriMatchesFormat(uri: Uri): Boolean {
-        return uriMatchesHost(uri) && uri.pathSegments.size == 2
-    }
-    fun uriMatchesHost(uri: Uri): Boolean {
-        return uri.scheme == scheme && uri.host == domain
-    }
     fun uriMatchesPoll(uri: Uri): Boolean {
-        return uriMatchesFormat(uri) && uri.pathSegments.first() == pollRoutePathSegment
-    }
-    fun uriMatchesBallots(uri: Uri): Boolean {
-        return uriMatchesFormat(uri) && uri.pathSegments.first() == ballotsRoutePathSegment
+        return uriMatchesFormat(uri) && uriMatchesRoutePrefix(uri, pollRoutePathSegment)
     }
 
+    fun uriMatchesBallots(uri: Uri): Boolean {
+        return uriMatchesFormat(uri) && uriMatchesRoutePrefix(uri, ballotsRoutePathSegment)
+    }
+
+    private fun uriMatchesFormat(uri: Uri): Boolean {
+        return uriMatchesHost(uri) && uri.pathSegments.isNotEmpty()
+    }
+
+    private fun uriMatchesHost(uri: Uri): Boolean {
+        return uri.scheme == scheme && (domain.isEmpty() || uri.host == domain)
+    }
+
+    private fun uriMatchesRoutePrefix(uri: Uri, prefix: String): Boolean {
+        return uri.pathSegments.first() == prefix
+            || (domain.isEmpty() && uri.host == prefix)
+    }
 }

--- a/app/src/main/java/com/illiouchine/jm/ui/screen/BallotsQrExportScreen.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/screen/BallotsQrExportScreen.kt
@@ -32,6 +32,7 @@ import com.illiouchine.jm.model.Grading
 import com.illiouchine.jm.model.Judgment
 import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.model.PollConfig
+import com.illiouchine.jm.service.ExchangeUriService
 import com.illiouchine.jm.ui.composable.ScreenTitle
 import com.illiouchine.jm.ui.composable.image.QrCodeImage
 import com.illiouchine.jm.ui.composable.scaffold.MjuScaffold
@@ -41,6 +42,7 @@ import com.illiouchine.jm.ui.theme.JmTheme
 import com.illiouchine.jm.ui.theme.Theme
 import com.illiouchine.jm.ui.theme.spacing
 import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
 import java.util.UUID
 import kotlin.random.Random
 
@@ -224,7 +226,10 @@ fun BallotsQrExportScreen(
     showSystemUi = true,
 )
 @Composable
-fun PreviewBallotsQrExportScreen(modifier: Modifier = Modifier) {
+fun PreviewBallotsQrExportScreen(
+    modifier: Modifier = Modifier,
+    exchangeUriService: ExchangeUriService = koinInject(),
+) {
     val poll = Poll(
         id = 42,
         uuid = UUID(1234567890123456789, 1234567890123456789),
@@ -260,6 +265,7 @@ fun PreviewBallotsQrExportScreen(modifier: Modifier = Modifier) {
     val ballotsQrExportViewModel = viewModel {
         BallotsQrExportViewModel(
             pollDataSource = pollDataSource,
+            exchangeUriService = exchangeUriService,
         )
     }
     ballotsQrExportViewModel.initializeFromPoll(

--- a/app/src/main/java/com/illiouchine/jm/ui/screen/BallotsQrImportScreen.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/screen/BallotsQrImportScreen.kt
@@ -27,13 +27,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.illiouchine.jm.R
 import com.illiouchine.jm.data.InMemoryPollDataSource
-import com.illiouchine.jm.logic.BallotsDto
 import com.illiouchine.jm.logic.BallotsQrImportViewModel
 import com.illiouchine.jm.model.Ballot
 import com.illiouchine.jm.model.Grading
 import com.illiouchine.jm.model.Judgment
 import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.model.PollConfig
+import com.illiouchine.jm.model.dto.BallotsDto
+import com.illiouchine.jm.service.ExchangeUriService
 import com.illiouchine.jm.ui.composable.ScreenTitle
 import com.illiouchine.jm.ui.composable.button.ActionRowCancelConfirm
 import com.illiouchine.jm.ui.composable.scaffold.MjuScaffold
@@ -47,6 +48,7 @@ import com.illiouchine.jm.ui.utils.encode
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.cbor.Cbor
 import kotlinx.serialization.encodeToByteArray
+import org.koin.compose.koinInject
 import java.util.UUID
 
 @Composable
@@ -233,7 +235,10 @@ fun BallotsQrImportScreen(
 // )
 // @PreviewScreenSizes // my eyes hurt ← no dark mode
 @Composable
-fun PreviewBallotsQrImportScreen(modifier: Modifier = Modifier) {
+fun PreviewBallotsQrImportScreen(
+    modifier: Modifier = Modifier,
+    exchangeUriService: ExchangeUriService = koinInject(),
+) {
     val poll = Poll(
         id = 17,
         uuid = UUID(66666669999999, 777111),
@@ -303,13 +308,14 @@ fun PreviewBallotsQrImportScreen(modifier: Modifier = Modifier) {
     val ballotsQrImportViewModel = viewModel {
         BallotsQrImportViewModel(
             pollDataSource = pollDataSource,
+            exchangeUriService = exchangeUriService,
         )
     }
 
     if (done) {
         ballotsQrImportViewModel.initialize(
             context = LocalContext.current,
-            qrUriPath = uriPath,
+            qrUriPathDatum = uriPath,
         )
         val state = ballotsQrImportViewModel.viewState.collectAsState().value
 

--- a/app/src/main/java/com/illiouchine/jm/ui/screen/PollQrExportScreen.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/screen/PollQrExportScreen.kt
@@ -29,6 +29,7 @@ import com.illiouchine.jm.logic.PollQrExportViewModel
 import com.illiouchine.jm.model.Grading
 import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.model.PollConfig
+import com.illiouchine.jm.service.ExchangeUriService
 import com.illiouchine.jm.ui.composable.ScreenTitle
 import com.illiouchine.jm.ui.composable.image.QrCodeImage
 import com.illiouchine.jm.ui.composable.scaffold.MjuScaffold
@@ -39,6 +40,7 @@ import com.illiouchine.jm.ui.theme.Theme
 import com.illiouchine.jm.ui.theme.spacing
 import kotlinx.coroutines.launch
 import kotlinx.serialization.ExperimentalSerializationApi
+import org.koin.compose.koinInject
 
 @OptIn(ExperimentalSerializationApi::class)
 @Composable
@@ -185,7 +187,10 @@ fun PollQrExportScreen(
 )
 // @PreviewScreenSizes // my eyes hurt ← no dark mode
 @Composable
-fun PreviewPollQrExportScreen(modifier: Modifier = Modifier) {
+fun PreviewPollQrExportScreen(
+    modifier: Modifier = Modifier,
+    exchangeUriService: ExchangeUriService = koinInject(),
+) {
     val poll = Poll(
         id = 17,
         pollConfig = PollConfig(
@@ -210,6 +215,7 @@ fun PreviewPollQrExportScreen(modifier: Modifier = Modifier) {
     val pollQrExportViewModel = viewModel {
         PollQrExportViewModel(
             pollDataSource = InMemoryPollDataSource(), // dummy
+            exchangeUriService = exchangeUriService,
         )
     }
     pollQrExportViewModel.initializeFromPoll(poll)

--- a/app/src/main/java/com/illiouchine/jm/ui/screen/PollQrImportScreen.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/screen/PollQrImportScreen.kt
@@ -25,6 +25,7 @@ import com.illiouchine.jm.logic.PollQrImportViewModel
 import com.illiouchine.jm.model.Grading
 import com.illiouchine.jm.model.Poll
 import com.illiouchine.jm.model.PollConfig
+import com.illiouchine.jm.service.ExchangeUriService
 import com.illiouchine.jm.ui.composable.ScreenTitle
 import com.illiouchine.jm.ui.composable.button.ActionRowCancelConfirm
 import com.illiouchine.jm.ui.composable.scaffold.MjuScaffold
@@ -38,6 +39,7 @@ import com.illiouchine.jm.ui.utils.encode
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.cbor.Cbor
 import kotlinx.serialization.encodeToByteArray
+import org.koin.compose.koinInject
 
 @OptIn(ExperimentalSerializationApi::class)
 @Composable
@@ -181,7 +183,10 @@ fun PollQrImportScreen(
     showSystemUi = true,
  )
 @Composable
-fun PreviewPollQrImportScreen(modifier: Modifier = Modifier) {
+fun PreviewPollQrImportScreen(
+    modifier: Modifier = Modifier,
+    exchangeUriService: ExchangeUriService = koinInject(),
+) {
     val poll = Poll(
         id = 17,
         pollConfig = PollConfig(
@@ -210,11 +215,13 @@ fun PreviewPollQrImportScreen(modifier: Modifier = Modifier) {
     val pollQrImportViewModel = viewModel {
         PollQrImportViewModel(
             pollDataSource = InMemoryPollDataSource(), // dummy
+            exchangeUriService = exchangeUriService,
+
         )
     }
     pollQrImportViewModel.initialize(
         context = LocalContext.current,
-        qrUriPath = compressedPollString,
+        qrUriPathDatum = compressedPollString,
     )
     val state = pollQrImportViewModel.viewState.collectAsState().value
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,47 @@
+
+
+## Deep App Links
+
+https://developer.android.com/training/app-links/create-deeplinks
+
+The default QR Code scanner does not support custom URL schemes (eg: `mju://`) since Android 12.
+
+Google decided to be fascist about this because they have not checked their privileges in a while
+and they assume that everyone has disposable money to throw away in domain and server renting.
+
+As usual, they hide this imperialism behind a goo of "it's for your own good, mom knows best".
+
+Therefore, we nned to also support App Links using the `https://` scheme.
+
+> Android queries the corresponding websites for the Digital Asset Links file
+> at https://hostname/.well-known/assetlinks.json
+
+
+### assetlinks.json
+
+> https://support.google.com/googleplay/android-developer/answer/16641489?hl=en
+
+```json
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "fr.mieuxvoter.urn",
+      "sha256_cert_fingerprints": [
+        "75:DF:18:56:85:89:C9:64:C9:5F:A2:13:1B:B4:E4:9F:21:8D:4B:DD:0E:3F:D9:D7:35:C0:28:CA:B0:D5:52:3F"
+      ]
+    }
+  },
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.illiouchine.jm",
+      "sha256_cert_fingerprints": [
+        "75:DF:18:56:85:89:C9:64:C9:5F:A2:13:1B:B4:E4:9F:21:8D:4B:DD:0E:3F:D9:D7:35:C0:28:CA:B0:D5:52:3F"
+      ]
+    }
+  }
+]
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,25 +21,37 @@ Therefore, we nned to also support App Links using the `https://` scheme.
 
 > https://support.google.com/googleplay/android-developer/answer/16641489?hl=en
 
+See file at https://mju.mieuxvoter.fr/.well-known/assetlinks.json
+
+#### Example contents
+
 ```json
 [
   {
-    "relation": ["delegate_permission/common.handle_all_urls"],
-    "target": {
-      "namespace": "android_app",
-      "package_name": "fr.mieuxvoter.urn",
-      "sha256_cert_fingerprints": [
-        "75:DF:18:56:85:89:C9:64:C9:5F:A2:13:1B:B4:E4:9F:21:8D:4B:DD:0E:3F:D9:D7:35:C0:28:CA:B0:D5:52:3F"
-      ]
-    }
-  },
-  {
-    "relation": ["delegate_permission/common.handle_all_urls"],
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
     "target": {
       "namespace": "android_app",
       "package_name": "com.illiouchine.jm",
       "sha256_cert_fingerprints": [
-        "75:DF:18:56:85:89:C9:64:C9:5F:A2:13:1B:B4:E4:9F:21:8D:4B:DD:0E:3F:D9:D7:35:C0:28:CA:B0:D5:52:3F"
+        "FC:D2:B7:03:0D:9A:0C:46:DC:C2:0E:0F:5F:C5:D2:E8:C0:29:67:6F:F5:23:1C:DB:C5:B3:86:56:36:6C:61:B2",
+        "75:DF:18:56:85:89:C9:64:C9:5F:A2:13:1B:B4:E4:9F:21:8D:4B:DD:0E:3F:D9:D7:35:C0:28:CA:B0:D5:52:3F",
+        "73:0E:BE:D1:B5:B5:A9:76:33:93:EA:2B:37:BD:0E:81:DE:3D:EB:3E:84:2A:64:F4:19:3C:CC:4E:5A:CC:11:98"
+      ]
+    }
+  },
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "fr.mieuxvoter.urn",
+      "sha256_cert_fingerprints": [
+        "FC:D2:B7:03:0D:9A:0C:46:DC:C2:0E:0F:5F:C5:D2:E8:C0:29:67:6F:F5:23:1C:DB:C5:B3:86:56:36:6C:61:B2",
+        "75:DF:18:56:85:89:C9:64:C9:5F:A2:13:1B:B4:E4:9F:21:8D:4B:DD:0E:3F:D9:D7:35:C0:28:CA:B0:D5:52:3F",
+        "73:0E:BE:D1:B5:B5:A9:76:33:93:EA:2B:37:BD:0E:81:DE:3D:EB:3E:84:2A:64:F4:19:3C:CC:4E:5A:CC:11:98"
       ]
     }
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ majority-judgment-library-java = { module = "com.github.MieuxVoter:majority-judg
 koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin-bom" }
 koin-core = { module = "io.insert-koin:koin-core" }
 koin-android = { module = "io.insert-koin:koin-android" }
+koin-compose = { module = "io.insert-koin:koin-compose" }
 androidx-room-runtime = { group ="androidx.room", name = "room-runtime", version.ref = "room"}
 androidx-room-compiler = { group ="androidx.room", name = "room-compiler", version.ref = "room"}
 androidx-room-ktx = { group ="androidx.room", name = "room-ktx", version.ref = "room"}

--- a/metadata/en-US/changelogs/24.txt
+++ b/metadata/en-US/changelogs/24.txt
@@ -1,0 +1,2 @@
+* Refactor daisy-chaining via QR codes
+* Refactor Composable previews to use dependency injection


### PR DESCRIPTION
In essence, we moved from `mju://` URIs to `https://` URIs.
With some refacto and cleanup along the way, of course.