### PR TITLE
Use the relative minimum in the proximity spider plot

### DIFF
--- a/app/src/main/java/com/illiouchine/jm/ui/composable/plot/ProximitySpider.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/composable/plot/ProximitySpider.kt
@@ -40,9 +40,10 @@ fun ProximitySpider(
 ) {
     val proposalsInitials = makeProposalsInitials(analysis)
 
+    val relativeMinimum = analysis.minima[selectedProposalIndex]
     val neutral = analysis.neutrals[selectedProposalIndex]
     val tickValues = buildList {
-        add(-1f)
+        add(relativeMinimum.toFloat())
         add(neutral.toFloat())
         add(1f)
     }

--- a/app/src/main/java/com/illiouchine/jm/ui/composable/plot/lib/SpiderChart.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/composable/plot/lib/SpiderChart.kt
@@ -13,12 +13,10 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.PaintingStyle.Companion.Stroke
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp

--- a/app/src/main/java/com/illiouchine/jm/ui/composable/plot/lib/SpiderChart.kt
+++ b/app/src/main/java/com/illiouchine/jm/ui/composable/plot/lib/SpiderChart.kt
@@ -13,8 +13,12 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.PaintingStyle.Companion.Stroke
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -75,9 +79,23 @@ fun SpiderChart(
             radialAxisModel = rememberFloatRadialAxisModel(tickValues),
             angularAxisModel = rememberCategoryAngularAxisModel(indexedCategories),
             radialAxisLabels = {
+                val labelValue = it.toDouble().smartFormat(tickDecimals)
+                val labelStyle = TextStyle.Default
+                // Outline
                 Text(
-                    text = it.toDouble().smartFormat(tickDecimals),
-                    style = TextStyle.Default,
+                    text = labelValue,
+                    style = labelStyle.copy(
+                        color = Theme.colorScheme.background,
+                        drawStyle = Stroke(
+                            width = 6f,
+                            join = StrokeJoin.Round,
+                        ),
+                    ),
+                )
+                // Fill
+                Text(
+                    text = labelValue,
+                    style = labelStyle,
                 )
             },
             angularAxisLabels = {


### PR DESCRIPTION
Also, add a small outline to the tick values, to make them more readable.

Fixes #254 